### PR TITLE
docs(test): state the naming rule as behaviour-first, not a should-template

### DIFF
--- a/__test__/CLAUDE.md
+++ b/__test__/CLAUDE.md
@@ -123,7 +123,13 @@ Load before migrating any suite to `it.effect`.
 
 ## Key Testing Rules
 
-- Never use `any` types; Arrange-Act-Assert; descriptive names (`"should X when Y"`)
+- Never use `any` types; Arrange-Act-Assert
+- __A test title states the observable behaviour — what happens, under what condition — in plain
+  language.__ `"should X when Y"` is one acceptable shape, not a required template, and
+  `"drops a write whose stamp is OLDER than what is already there"` is equally good: it carries
+  the condition without the prefix. Rename a title only when it fails to communicate the
+  behaviour. __Do not sweep a suite to fit the template__ — a mechanical rewrite adds length, not
+  clarity, and churns diffs for no reader's benefit
 - Cover all code paths (branches, switch cases, error handling)
 - A test pinning known-wrong behaviour says `CHARACTERIZATION`, names the issue, and is written to
   fail when the fix lands — 18 exist for issue #216. Do not "fix" one to make it pass


### PR DESCRIPTION
## Summary

`__test__/CLAUDE.md`'s Key Testing Rules prescribed `"should X when Y"` as the shape for test titles. This replaces that with the rule the repo actually follows, and that the cross-repo position settles on: **a test title states the observable behaviour — what happens, under what condition — in plain language.** The `should` prefix is one acceptable shape, not a required template.

## Why this needed changing rather than enforcing

The line was the last thing still asking for a mechanical rewrite of roughly 30 existing titles. That sweep was scoped out of [#192](https://github.com/savvy-web/silk-release-action/issues/192), and when it came up for decision it was declined on review — sampling every flagged suite showed the titles are already third-person behaviour statements carrying their condition, where the prefix adds length rather than clarity. The issue's own example makes the point:

```text
leaves the section CANCELLED when the branch work is interrupted
```

That communicates the behaviour and the condition without a `should`. Rewriting it to fit the template would be a worse title and a churned diff.

So the guidance and the codebase disagreed, and the guidance was the wrong half. Leaving it in place means the next reader — human or agent — keeps re-proposing the sweep, which is exactly what happened during #192.

## What the rule now says

- State the observable behaviour, in plain language.
- `"should X when Y"` is acceptable; so is a bare third-person statement that carries its condition.
- Rename a title only when it **fails to communicate the behaviour**.
- Do not sweep a suite to fit the template.

## Scope

Documentation only — one file, seven lines. No test was renamed, no code changed, no behaviour affected. `pnpm lint:md` reports 0 issues.

Verified this was the only place asserting the template: a repo-wide search for `should X when Y` and `descriptive names` outside `dist/` now returns only the corrected line itself.

## No changeset, deliberately

`__test__/CLAUDE.md` is agent-facing guidance. It ships in neither `dist/main.js` nor `action.yml`, and nothing about a consumer's use of this action changes. A changeset would put an internal test-naming convention into the published CHANGELOG. Happy to add one if you'd rather every tracked file carry an entry — cheap either way.

## Context

Closes out the last item deferred from the #192 review cycle. The code half shipped in #234; this is the guidance half, which was deliberately held back because amending an instruction file was a maintainer decision rather than something to settle between sessions.
